### PR TITLE
[BUILD] Fix Clang compilation with GLM dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ FetchContent_Declare(
     glm
     GIT_REPOSITORY https://github.com/g-truc/glm
     GIT_TAG 1.0.0
+    SYSTEM
 )
 
 # FetchContent_Declare(imgui...)


### PR DESCRIPTION
## Description
Fixed a compilation error with a GLM dependency related to the Clang compiler. The bug was fixed by using the SYSTEM keyword in the root CMake file.

## Changes
[BUILD] Fix Clang compilation with GLM dependency

## Testing
- [x] Manual review of all markdown files
- [x] Verified links and formatting
- [ ] Unit tests (N/A)

## Documentation
- [x] User documentation created
- [x] Development workflow documented
- [x] Coding standards established